### PR TITLE
app.json: rm unnecessary vars

### DIFF
--- a/app.json
+++ b/app.json
@@ -19,14 +19,6 @@
     "SECRET_STORE_BASE": {
       "required": true,
       "generator": "secret"
-    },
-    "SELFSIGNEDCERT": {
-      "required": true,
-      "value": "0"
-    },
-    "GRAX_TEMPLATE_VERSION": {
-      "required": true,
-      "value": "heroku:v1.0.0"
     }
   }
 }


### PR DESCRIPTION
related https://github.com/graxinc/grax/issues/11554

SELFSIGNEDCERT and GRAX_TEMPLATE_VERSION are no longer required.